### PR TITLE
Magnometer code fix and enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.eslintrc

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ var mpu = new mpu9250({
     // Enable/Disable magnetometer data (default false)
     UpMagneto: true,
 
+    // If true, all values returned will be scaled to actual units (default false).
+    // If false, the raw values from the device will be returned.
+    scaleValues: false,
+
     // Enable/Disable debug mode (default false)
-    DEBUG: true,
+    DEBUG: false,
 
     // ak8963 (magnetometer / compass) address (default is 0x0C)
     ak_address: 0x0C,

--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ var mpu = new mpu9250({
 });
 ```
 
+## Calibration
+
+All three sensors can be calibrated and the calibrated values provided as options.  See the `example.js` file for how
+to apply the calibrated values.  Run the `calibrate_accel.js`, `calibrate_mag.js` and `calibrate_gyro.js` to calibrate
+the relevant sensors.  The output will display some JSON text, copy and paste this into your code. See the relevant
+JavaScript source file for the documentation on the calibration. 
+
 ## Integration of Calman Filter
 ###Example :
 ```javascript

--- a/calibrate_accel.js
+++ b/calibrate_accel.js
@@ -1,9 +1,45 @@
+///////////////////////////////////////////////////////////////////////////////////////
+//***********************************************************************************//
+//**                                                                               **//
+//**                                                                               **//
+//** The MIT License (MIT)                                                         **//
+//**                                                                               **//
+//** Copyright (c) <2016> <Simon M. Werner>                                        **//
+//**                                                                               **//
+//** Permission is hereby granted, free of charge, to any person obtaining a copy  **//
+//** of this software and associated documentation files (the "Software"), to deal **//
+//** in the Software without restriction, including without limitation the rights  **//
+//** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell     **//
+//** copies of the Software, and to permit persons to whom the Software is         **//
+//** furnished to do so, subject to the following conditions:                      **//
+//**                                                                               **//
+//** The above copyright notice and this permission notice shall be included in    **//
+//** all copies or substantial portions of the Software.                           **//
+//**                                                                               **//
+//** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR    **//
+//** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      **//
+//** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE   **//
+//** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        **//
+//** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, **//
+//** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN     **//
+//** THE SOFTWARE.                                                                 **//
+//**                                                                               **//
+//***********************************************************************************//
+///////////////////////////////////////////////////////////////////////////////////////
+
 'use strict';
 
 var NUM_READS = 300;
 
 /**
- * Calibrate the Accelerometer.  This device will need to be rotated with the X, Y and Z axes up.
+ * Calibrate the Accelerometer.  This device will need to be rotated with the X, Y and Z axes up and down.  The axis
+ * you point up/down will be calibrated against gravity (so you must have it vertical).  You may want to hold it against
+ * a wall or similar.  While the one axis is being calibrated against gravity, the other two axes will be perpendicular
+ * to gravity, so will read near zero, this value will be used as the offset.
+ *
+ * The scaling is simple linear scaling, based on the common formular for a line, y = m * x + c, where y is our scaled
+ * and offset result, while x is the raw value.  This formular is actually applied in the main mpu9250.js file.  But
+ * this calibration process outputs those values.
  */
 
 // Instantiate and initialize.

--- a/calibrate_accel.js
+++ b/calibrate_accel.js
@@ -1,0 +1,122 @@
+'use strict';
+
+var NUM_READS = 300;
+
+/**
+ * Calibrate the Accelerometer.  This device will need to be rotated with the X, Y and Z axes up.
+ */
+
+// Instantiate and initialize.
+var mpu9250 = require('./mpu9250');
+var sleep = require('sleep');
+
+var mpu = new mpu9250({
+    device: '/dev/i2c-2',
+    scaleValues: true,
+    UpMagneto: false
+});
+
+var axis = -1;
+var axes = ['X', 'Y', 'Z'];
+var dir = 'down';
+var directions = {
+    'up': 1,
+    'down': -1
+};
+var offset = [0, 0, 0];
+var scale = [[0, 0], [0, 0], [0, 0]];
+
+if (mpu.initialize()) {
+    runNextCapture();
+}
+
+/**
+ * Set up the next capture for an axis and a direction (up / down).
+ */
+function runNextCapture() {
+    if (dir === 'up') {
+        dir = 'down';
+    } else {
+        axis += 1;
+        dir = 'up';
+    }
+    if (axis === 3) {
+        wrapUp();
+    }
+    console.log('Point the ' + axes[axis] + ' axis arrow ' + dir + '.');
+    pressEnterKeyToContinue(function () {
+        calibrateAxis(axis, dir);
+        runNextCapture();
+    });
+}
+
+/**
+ * This will syncronuously read the accel data from MPU9250.  It will gather the offset and scalar values.
+ */
+function calibrateAxis() {
+    var scaleDir = dir === 'down' ? 0 : 1;
+
+    console.log('Reading values - hold still');
+    for (var i = 0; i < NUM_READS; i++) {
+        var accelValues = mpu.getAccel();
+
+        for (var a = 0; a < 3; a += 1) {
+            if (a === axis) {
+                scale[a][scaleDir] += accelValues[a];
+            } else {
+                offset[a] += accelValues[a];
+            }
+        }
+        sleep.usleep(5000);
+    }
+}
+
+/**
+ * Called when we are done.
+ */
+function wrapUp() {
+    for (var i = 0; i < 3; i++) {
+        offset[i] = offset[i] / (NUM_READS * 4);
+        scale[i][0] = scale[i][0] / NUM_READS;
+        scale[i][1] = scale[i][1] / NUM_READS;
+    }
+    var calibration = {
+        offset: {
+            x: offset[0],
+            y: offset[1],
+            z: offset[2]
+        },
+        scale: {
+            x: scale[0],
+            y: scale[1],
+            z: scale[2]
+        }
+    };
+
+    console.log('ACCEL_CALIBRATION = ', calibration);
+    var exit = process.exit;
+    exit();
+}
+
+/**
+ * This will ask the user to press the ENTER key to continue.  Then run the callback.
+ * @param  {Function} callback
+ */
+function pressEnterKeyToContinue(callback) {
+    console.log('Press ENTER to continue.');
+
+    process.stdin.resume();
+    process.stdin.setEncoding('utf8');
+    var util = require('util');
+
+    var called = false;
+    process.stdin.on('data', function (text) {
+        if (called) return;
+        if (text === '\n') {
+            called = true;
+            callback();
+            console.log();
+        }
+    });
+
+}

--- a/calibrate_gyro.js
+++ b/calibrate_gyro.js
@@ -1,16 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////////////
+//***********************************************************************************//
+//**                                                                               **//
+//**                                                                               **//
+//** The MIT License (MIT)                                                         **//
+//**                                                                               **//
+//** Copyright (c) <2016> <Simon M. Werner>                                        **//
+//**                                                                               **//
+//** Permission is hereby granted, free of charge, to any person obtaining a copy  **//
+//** of this software and associated documentation files (the "Software"), to deal **//
+//** in the Software without restriction, including without limitation the rights  **//
+//** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell     **//
+//** copies of the Software, and to permit persons to whom the Software is         **//
+//** furnished to do so, subject to the following conditions:                      **//
+//**                                                                               **//
+//** The above copyright notice and this permission notice shall be included in    **//
+//** all copies or substantial portions of the Software.                           **//
+//**                                                                               **//
+//** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR    **//
+//** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      **//
+//** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE   **//
+//** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        **//
+//** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, **//
+//** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN     **//
+//** THE SOFTWARE.                                                                 **//
+//**                                                                               **//
+//***********************************************************************************//
+///////////////////////////////////////////////////////////////////////////////////////
+
 'use strict';
 
 var NUM_READS = 500;
 
 /**
  * Calibrate the gyro.  The device needs to remain still during calibration.  The calibration will
- * be applied to the gyro.
+ * be applied to the gyro.  This is only simple calibration for Gyro bias for when the Gyro is still.
+ * More sophisticated calibration tools can be applied.
  *
  * NOTE: The Gyro must not be moved during this process.
  *
- * @name gyroBiasCalibrationSync
- * @param {number} numReads The number of cycles to average the gyro values.
- * @return {Array} The averaged [x, y, z] values for the gyro.
  */
 
 // Instantiate and initialize.

--- a/calibrate_gyro.js
+++ b/calibrate_gyro.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var NUM_READS = 500;
+
+/**
+ * Calibrate the gyro.  The device needs to remain still during calibration.  The calibration will
+ * be applied to the gyro.
+ *
+ * NOTE: The Gyro must not be moved during this process.
+ *
+ * @name gyroBiasCalibrationSync
+ * @param {number} numReads The number of cycles to average the gyro values.
+ * @return {Array} The averaged [x, y, z] values for the gyro.
+ */
+
+// Instantiate and initialize.
+var mpu9250 = require('./mpu9250');
+var sleep = require('sleep');
+
+var mpu = new mpu9250({
+    device: '/dev/i2c-2',
+    scaleValues: true,
+    UpMagneto: false
+});
+
+function gyroBiasCalibrationSync() {
+
+	// Reset the calibration
+	mpu._config.gyroBiasCalibration = { x: 0, y: 0, z: 0 };
+
+	var avg = {
+		x: 0,
+		y: 0,
+		z: 0
+	};
+
+	for (var i = 0; i < NUM_READS; i++) {
+		var gyroValues = mpu.getGyro();
+		avg.x += gyroValues[0];
+		avg.y += gyroValues[1];
+		avg.z += gyroValues[2];
+		sleep.usleep(5000);
+	}
+
+	avg.x /= -NUM_READS;
+	avg.y /= -NUM_READS;
+	avg.z /= -NUM_READS;
+
+	return avg;
+}
+
+
+if (mpu.initialize()) {
+    console.log('Calibrating.');
+    console.log('GYRO_OFFSET =', gyroBiasCalibrationSync());
+}

--- a/calibrate_gyro.js
+++ b/calibrate_gyro.js
@@ -25,9 +25,6 @@ var mpu = new mpu9250({
 
 function gyroBiasCalibrationSync() {
 
-	// Reset the calibration
-	mpu._config.gyroBiasCalibration = { x: 0, y: 0, z: 0 };
-
 	var avg = {
 		x: 0,
 		y: 0,

--- a/calibrate_mag.js
+++ b/calibrate_mag.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * Calibarate the magnometer.
+ *
+ * Usage:
+ *     node calibrate_mag.js
+ *
+ * The output will be JSON text.  You can use this as input for the mpu9250, as an option.
+ *
+ * These calibration calculations are based on this page:
+ * http://www.camelsoftware.com/2016/03/13/imu-maths-calculate-orientation-pt3/
+ */
+
+// Instantiate and initialize.
+var mpu9250 = require('./mpu9250');
+var mpu = new mpu9250({
+    device: '/dev/i2c-2',
+    scaleValues: true,
+    UpMagneto: true
+});
+
+var min = {
+    x: Infinity,
+    y: Infinity,
+    z: Infinity
+};
+var max = {
+    x: -Infinity,
+    y: -Infinity,
+    z: -Infinity
+};
+var count = 0;
+var MAX_NUM = 1000;
+
+console.log('Rotate the magnometer around all 3 axes, until the min and max values don\'t change anymore.');
+
+if (mpu.initialize()) {
+
+    console.log('    x        y        z      min x    min y    min z    max x    max y    max z');
+
+    setInterval(function () {
+        if (count++ > MAX_NUM) {
+            wrapUp();
+        }
+        var magdata = mpu.ak8963.getMagAttitude();
+        min.x = Math.min(min.x, magdata[0]);
+        min.y = Math.min(min.y, magdata[1]);
+        min.z = Math.min(min.z, magdata[2]);
+
+        max.x = Math.max(max.x, magdata[0]);
+        max.y = Math.max(max.y, magdata[1]);
+        max.z = Math.max(max.z, magdata[2]);
+
+        process.stdout.write(p(magdata[0]) + p(magdata[1]) + p(magdata[2]) + p(min.x) + p(min.y) + p(min.z) + p(max.x) + p(max.y) + p(max.z) + '\r');
+    }, 50);
+}
+
+function p(num) {
+    var str = num.toFixed(3);
+    while (str.length <= 7) {
+        str = ' ' + str;
+    }
+    return str + ' ';
+}
+
+var offset = {};
+var scale = {};
+function calcCalibration() {
+    offset = {
+        x: (min.x + max.x) / 2,
+        y: (min.y + max.y) / 2,
+        z: (min.z + max.z) / 2
+    };
+    var vmax = {
+        x: max.x - ((min.x + max.x) / 2),
+        y: max.y - ((min.y + max.y) / 2),
+        z: max.z - ((min.z + max.z) / 2)
+    };
+    var vmin = {
+        x: min.x - ((min.x + min.x) / 2),
+        y: min.y - ((min.y + min.y) / 2),
+        z: min.z - ((min.z + min.z) / 2)
+    };
+    var avg = {
+        x: (vmax.x - vmin.x) / 2,
+        y: (vmax.y - vmin.y) / 2,
+        z: (vmax.z - vmin.z) / 2
+    };
+    var avg_radius = (avg.x + avg.y + avg.z) / 2;
+    scale = {
+        x: avg_radius / avg.x,
+        y: avg_radius / avg.y,
+        z: avg_radius / avg.z
+    };
+}
+
+function wrapUp() {
+    console.log('\n');
+    calcCalibration();
+    console.log({
+        min: min,
+        max: max,
+        offset: offset,
+        scale: scale
+    });
+
+    var exit = process.exit;
+    exit(0);
+}

--- a/calibrate_mag.js
+++ b/calibrate_mag.js
@@ -1,3 +1,32 @@
+///////////////////////////////////////////////////////////////////////////////////////
+//***********************************************************************************//
+//**                                                                               **//
+//**                                                                               **//
+//** The MIT License (MIT)                                                         **//
+//**                                                                               **//
+//** Copyright (c) <2016> <Simon M. Werner>                                        **//
+//**                                                                               **//
+//** Permission is hereby granted, free of charge, to any person obtaining a copy  **//
+//** of this software and associated documentation files (the "Software"), to deal **//
+//** in the Software without restriction, including without limitation the rights  **//
+//** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell     **//
+//** copies of the Software, and to permit persons to whom the Software is         **//
+//** furnished to do so, subject to the following conditions:                      **//
+//**                                                                               **//
+//** The above copyright notice and this permission notice shall be included in    **//
+//** all copies or substantial portions of the Software.                           **//
+//**                                                                               **//
+//** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR    **//
+//** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,      **//
+//** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE   **//
+//** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER        **//
+//** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, **//
+//** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN     **//
+//** THE SOFTWARE.                                                                 **//
+//**                                                                               **//
+//***********************************************************************************//
+///////////////////////////////////////////////////////////////////////////////////////
+
 'use strict';
 
 /**
@@ -5,6 +34,9 @@
  *
  * Usage:
  *     node calibrate_mag.js
+ *
+ * Once the calibration is started you will want to move the sensor around all axes.  What we want is to find the
+ * extremes (min/max) of the x, y, z values such that we can find the offset and scale values.
  *
  * The output will be JSON text.  You can use this as input for the mpu9250, as an option.
  *

--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@
 
 var mpu9250 = require('./mpu9250');
 
-// These values were generated using calibrate_mag
+// These values were generated using calibrate_mag - you will want to create your own.
 var MAG_CALIBRATION = {
     min: { x: -106.171875, y: -56.8125, z: -14.828125 },
     max: { x: 71.9609375, y: 117.17578125, z: 164.25 },
@@ -13,6 +13,15 @@ var MAG_CALIBRATION = {
         z: 1.483149376145188
     }
 };
+
+// These values were generated using calibrate_gyro - you will want to create your own.
+// NOTE: These are temperature dependent.
+var GYRO_OFFSET = {
+    x: -1.068045801526718,
+    y: -0.15665648854961847,
+    z: 1.384625954198473
+};
+
 
 // Instantiate and initialize.
 var mpu = new mpu9250({
@@ -40,7 +49,9 @@ var mpu = new mpu9250({
 
     UpMagneto: true,
 
-    magCalibration: MAG_CALIBRATION
+    magCalibration: MAG_CALIBRATION,
+
+    gyroBiasOffset: GYRO_OFFSET
 });
 
 if (mpu.initialize()) {

--- a/example.js
+++ b/example.js
@@ -1,4 +1,5 @@
 var mpu9250 = require('./mpu9250');
+
 // Instantiate and initialize.
 var mpu = new mpu9250({
     // i2c path (default is '/dev/i2c-1')
@@ -21,15 +22,22 @@ var mpu = new mpu9250({
     //      3 => +/- 16 g
     ACCEL_FS: 2,
 
+    scaleValues: true,
+
     UpMagneto: true
 });
 
 if (mpu.initialize()) {
+
     setInterval(function() {
         var start = new Date().getTime();
         var m9 = mpu.getMotion9();
         var end = new Date().getTime();
 
-        console.log((end - start) / 1000, m9);
+        for (var i = 0; i < m9.length; i++) {
+            m9[i] = m9[i].toFixed(2);
+        }
+
+        console.log((end - start) / 1000 + '\t' + m9.toString().replace(/,/g, '\t'));
     }, 5);
 }

--- a/example.js
+++ b/example.js
@@ -1,0 +1,35 @@
+var mpu9250 = require('./mpu9250');
+// Instantiate and initialize.
+var mpu = new mpu9250({
+    // i2c path (default is '/dev/i2c-1')
+    device: '/dev/i2c-2',
+
+    // Enable/Disable debug mode (default false)
+    DEBUG: true,
+
+    // Set the Gyroscope sensitivity (default 0), where:
+    //      0 => 250 degrees / second
+    //      1 => 500 degrees / second
+    //      2 => 1000 degrees / second
+    //      3 => 2000 degrees / second
+    GYRO_FS: 0,
+
+    // Set the Accelerometer sensitivity (default 2), where:
+    //      0 => +/- 2 g
+    //      1 => +/- 4 g
+    //      2 => +/- 8 g
+    //      3 => +/- 16 g
+    ACCEL_FS: 2,
+
+    UpMagneto: true
+});
+
+if (mpu.initialize()) {
+    setInterval(function() {
+        var start = new Date().getTime();
+        var m9 = mpu.getMotion9();
+        var end = new Date().getTime();
+
+        console.log((end - start) / 1000, m9);
+    }, 5);
+}

--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@
 
 var mpu9250 = require('./mpu9250');
 
-// These values were generated using calibrate_mag - you will want to create your own.
+// These values were generated using calibrate_mag.js - you will want to create your own.
 var MAG_CALIBRATION = {
     min: { x: -106.171875, y: -56.8125, z: -14.828125 },
     max: { x: 71.9609375, y: 117.17578125, z: 164.25 },
@@ -14,14 +14,27 @@ var MAG_CALIBRATION = {
     }
 };
 
-// These values were generated using calibrate_gyro - you will want to create your own.
+// These values were generated using calibrate_gyro.js - you will want to create your own.
 // NOTE: These are temperature dependent.
 var GYRO_OFFSET = {
-    x: -1.068045801526718,
-    y: -0.15665648854961847,
-    z: 1.384625954198473
+    x: -1.068045801,
+    y: -0.156656488,
+    z: 1.3846259541
 };
 
+// These values were generated using calibrate_accel.js - you will want to create your own.
+var ACCEL_CALIBRATION = {
+    offset: {
+        x: 0.00943176,
+        y: 0.00170817,
+        z: 0.05296142
+    },
+    scale: {
+        x: [-0.9931640, 1.0102189],
+        y: [-0.9981974, 1.0055884],
+        z: [-0.9598844, 1.0665967]
+    }
+};
 
 // Instantiate and initialize.
 var mpu = new mpu9250({
@@ -51,7 +64,9 @@ var mpu = new mpu9250({
 
     magCalibration: MAG_CALIBRATION,
 
-    gyroBiasOffset: GYRO_OFFSET
+    gyroBiasOffset: GYRO_OFFSET,
+
+    accelCalibration: ACCEL_CALIBRATION
 });
 
 if (mpu.initialize()) {

--- a/example.js
+++ b/example.js
@@ -20,7 +20,7 @@ var mpu = new mpu9250({
     //      1 => +/- 4 g
     //      2 => +/- 8 g
     //      3 => +/- 16 g
-    ACCEL_FS: 2,
+    ACCEL_FS: 0,
 
     scaleValues: true,
 
@@ -29,15 +29,17 @@ var mpu = new mpu9250({
 
 if (mpu.initialize()) {
 
+    console.log('Time\tAccel.x\tAccel.y\tAccel.z\tGyro.x\tGyro.y\tGyro.z\tMag.x\tMag.y\tMag.z\tTemp(°C)');
     setInterval(function() {
         var start = new Date().getTime();
         var m9 = mpu.getMotion9();
         var end = new Date().getTime();
 
+        // Make the numbers pretty
         for (var i = 0; i < m9.length; i++) {
             m9[i] = m9[i].toFixed(2);
         }
 
-        console.log((end - start) / 1000 + '\t' + m9.toString().replace(/,/g, '\t'));
+        console.log((end - start) / 1000 + '\t' + m9.toString().replace(/,/g, '\t') + '\t' + mpu.getTemperatureCelsiusDigital().toFixed(2));
     }, 5);
 }

--- a/mpu9250.js
+++ b/mpu9250.js
@@ -626,9 +626,9 @@ mpu9250.prototype.printSettings = function() {
 	this.debug.Log('INFO', '--> Device address: 0x' + this._config.address.toString(16));
 	this.debug.Log('INFO', '--> i2c bus: ' + this._config.device);
     this.debug.Log('INFO', '--> Device ID: 0x' + this.getIDDevice().toString(16));
-    this.debug.Log('INFO', '--> BYPASS enabled:', this.getByPASSEnabled() ? 'Yes' : 'No');
-	this.debug.Log('INFO', '--> SleepEnabled Mode:', this.getSleepEnabled() === 1 ? 'On' : 'Off');
-	this.debug.Log('INFO', '--> i2c Master Mode:', this.getI2CMasterMode() === 1 ? 'Enabled' : 'Disabled');
+    this.debug.Log('INFO', '--> BYPASS enabled: ' + (this.getByPASSEnabled() ? 'Yes' : 'No'));
+	this.debug.Log('INFO', '--> SleepEnabled Mode: ' + (this.getSleepEnabled() === 1 ? 'On' : 'Off'));
+	this.debug.Log('INFO', '--> i2c Master Mode: ' + (this.getI2CMasterMode() === 1 ? 'Enabled' : 'Disabled'));
     this.debug.Log('INFO', '--> Power Management (0x6B, 0x6C):');
     this.debug.Log('INFO', '    --> Clock Source: ' + CLK_RNG[this.getClockSource()]);
     this.debug.Log('INFO', '    --> Accel enabled (x, y, z): ' + vectorToYesNo(this.getAccelPowerSettings()));
@@ -647,15 +647,15 @@ function vectorToYesNo(v) {
 mpu9250.prototype.printAccelSettings = function() {
     var FS_RANGE = [ '±2g (0)', '±4g (1)', '±8g (2)', '±16g (3)' ];
 	this.debug.Log('INFO', 'Accelerometer:');
-	this.debug.Log('INFO', '--> Full Scale Range (0x1C):', FS_RANGE[this.getFullScaleAccelRange()]);
-	this.debug.Log('INFO', '--> Scalar: 1/' + 1 / this.accelScalarInv);
+	this.debug.Log('INFO', '--> Full Scale Range (0x1C): ' + FS_RANGE[this.getFullScaleAccelRange()]);
+	this.debug.Log('INFO', '--> Scalar: 1/' + (1 / this.accelScalarInv));
 };
 
 mpu9250.prototype.printGyroSettings = function() {
     var FS_RANGE = ['+250dps (0)', '+500 dps (1)', '+1000 dps (2)', '+2000 dps (3)'];
 	this.debug.Log('INFO', 'Gyroscope:');
-    this.debug.Log('INFO', '--> Full Scale Range (0x1B):', FS_RANGE[this.getFullScaleGyroRange()]);
-	this.debug.Log('INFO', '--> Scalar: 1/' + 1 / this.gyroScalarInv);
+    this.debug.Log('INFO', '--> Full Scale Range (0x1B): ' + FS_RANGE[this.getFullScaleGyroRange()]);
+	this.debug.Log('INFO', '--> Scalar: 1/' + (1 / this.gyroScalarInv));
 };
 
 

--- a/mpu9250.js
+++ b/mpu9250.js
@@ -701,6 +701,10 @@ ak8963.prototype.printSettings = function() {
 	this.debug.Log('INFO', '--> i2c address: 0x' + this._config.ak_address.toString(16));
 	this.debug.Log('INFO', '--> Device ID: 0x' + this.getIDDevice().toString(16));
 	this.debug.Log('INFO', '--> Mode: ' + MODE_LST[this.getCNTL() & 0x0F]);
+	this.debug.Log('INFO', '--> Scalars:');
+	this.debug.Log('INFO', '  --> x: ' + this.asax);
+	this.debug.Log('INFO', '  --> y: ' + this.asay);
+	this.debug.Log('INFO', '  --> z: ' + this.asaz);
 };
 
 /**------------------|[ FUNCTION ]|------------------**/

--- a/mpu9250.js
+++ b/mpu9250.js
@@ -1,14 +1,14 @@
 /**
- * 
+ *
  * NodeJs Module : MPU9250
  * @author BENKHADRA Hocine
  * @description Simple reading data for node js and mpu9250
  * @version 0.0.1
  * @dependent i2c, extend, sleep
  * @license MIT
- * 
+ *
  */
- 
+
 ///////////////////////////////////////////////////////////////////////////////////////
 //***********************************************************************************//
 //**                                                                               **//
@@ -40,7 +40,7 @@
 
 /*********************/
 /** Module required **/
-/*********************/ 
+/*********************/
 var MOD_I2C = require('i2c');
 var extend = require('extend');
 var sleep = require('sleep');
@@ -52,13 +52,13 @@ var MPU9250 = {
 	ADDRESS_AD0_LOW: 0x68,
 	ADDRESS_AD0_HIGHT: 0x69,
 	WHO_AM_I: 0x75,
-	
+
 	RA_CONFIG: 0x1A,
 	RA_GYRO_CONFIG: 0x1B,
 	RA_ACCEL_CONFIG: 0x1C,
-	
+
 	RA_INT_PIN_CFG: 0x37,
-	
+
 	INTCFG_ACTL_BIT: 7,
 	INTCFG_OPEN_BIT: 6,
 	INTCFG_LATCH_INT_EN_BIT_BIT: 5,
@@ -67,7 +67,7 @@ var MPU9250 = {
 	INTCFG_FSYNC_INT_MODE_EN_BIT: 2,
 	INTCFG_BYPASS_EN_BIT: 1,
 	INTCFG_NONE_BIT: 0,
-	
+
 	BY_PASS_MODE: 0x02,
 
 	ACCEL_XOUT_H: 0x3B,
@@ -84,25 +84,25 @@ var MPU9250 = {
 	GYRO_YOUT_L: 0x46,
 	GYRO_ZOUT_H: 0x47,
 	GYRO_ZOUT_L: 0x48,
-	
+
 	RA_USER_CTRL: 0x6A,
 	RA_PWR_MGMT_1: 0x6B,
 	RA_PWR_MGMT_2: 0x6C,
 	PWR1_DEVICE_RESET_BIT: 7,
-	PWR1_SLEEP_BIT:6,
+	PWR1_SLEEP_BIT: 6,
 	PWR1_CYCLE_BIT: 5,
 	PWR1_TEMP_DIS_BIT: 3,
 	PWR1_CLKSEL_BIT: 2,
 	PWR1_CLKSEL_LENGTH: 3,
-	
+
 	GCONFIG_FS_SEL_BIT: 4,
 	GCONFIG_FS_SEL_LENGTH: 2,
-	
+
 	GYRO_FS_250: 0x00,
 	GYRO_FS_500: 0x01,
 	GYRO_FS_1000: 0x02,
 	GYRO_FS_2000: 0x03,
-	
+
 	CLOCK_INTERNAL: 0x00,
 	CLOCK_PLL_XGYRO: 0x01,
 	CLOCK_PLL_YGYRO: 0x02,
@@ -117,11 +117,11 @@ var MPU9250 = {
 	ACCEL_FS_4: 0x01,
 	ACCEL_FS_8: 0x02,
 	ACCEL_FS_16: 0x03,
-	
+
 	I2C_SLV0_DO: 0x63,
 	I2C_SLV1_DO: 0x64,
 	I2C_SLV2_DO: 0x65,
-	
+
 	USERCTRL_DMP_EN_BIT: 7,
 	USERCTRL_FIFO_EN_BIT: 6,
 	USERCTRL_I2C_MST_EN_BIT: 5,
@@ -153,13 +153,13 @@ var AK8963 = {
 	ASAX: 0x10,  // Fuse ROM x-axis sensitivity adjustment value
 	ASAY: 0x11,  // Fuse ROM y-axis sensitivity adjustment value
 	ASAZ: 0x12,
-	
+
 	WHO_AM_I_BIT: 1,
 	CNTL_MODE_BIT: 0,
-	
+
 	ST1_DRDY_BIT: 0,
 	ST1_DOR_BIT: 1,
-	
+
 	CNTL_MODE_OFF: 0x00, // Power-down mode
 	CNTL_MODE_SINGLE_MESURE: 0x01, // Single measurement mode
 	CNTL_MODE_CONTINUE_MESURE_1: 0x02, // Continuous measurement mode 1
@@ -183,7 +183,7 @@ var mpu9250 = function(cfg) {
 	cfg = cfg || {};
 	if (typeof cfg != "object")
 		cfg = {};
-	
+
 	var _default = {
 		device: '/dev/i2c-1',
 		address: MPU9250.ADDRESS_AD0_LOW,
@@ -193,9 +193,12 @@ var mpu9250 = function(cfg) {
 		GYRO_FS: 0,
 		ACCEL_FS: 2
 	};
-	
-	config = extend({}, _default,cfg);
+
+	var config = extend({}, _default, cfg);
 	this._config = config;
+
+    this.MPU9250 = MPU9250;
+    this.AK8963 = AK8963;
 };
 
 /**
@@ -205,51 +208,53 @@ var mpu9250 = function(cfg) {
 mpu9250.prototype.initialize = function() {
 	this.i2c = new LOCAL_I2C(this._config.address, {device: this._config.device});
 	this.debug = new debugConsole(this._config.DEBUG);
-	this.debug.Log('INFO','device address is 0x' + this._config.address.toString(16) + ', device is ' + this._config.device);
-	this.debug.Log('INFO','Initialization MPU9250 ....');
-	
+	this.debug.Log('INFO', 'device address is 0x' + this._config.address.toString(16) + ', device is ' + this._config.device);
+	this.debug.Log('INFO', 'Initialization MPU9250 ....');
+
 	// clear configuration
 	this.i2c.writeBit(MPU9250.PWR_MGMT_1, 1, 0x80, function() {});
 	this.debug.Log('INFO', 'Reset configuration MPU9250.');
 	sleep.usleep(10000);
-	
+
 	// define clock source
 	this.setClockSource(MPU9250.CLOCK_PLL_XGYRO);
 	this.debug.Log('INFO', 'ClockSource to 0x' + MPU9250.CLOCK_PLL_XGYRO.toString(16));
 	sleep.usleep(10000);
-	
+
 	// define gyro range
-	gyro_fs = [MPU9250.GYRO_FS_250, MPU9250.GYRO_FS_500, MPU9250.GYRO_FS_1000, MPU9250.GYRO_FS_2000];	
-	gyro_value = MPU9250.GYRO_FS_250;
+	var gyro_fs = [MPU9250.GYRO_FS_250, MPU9250.GYRO_FS_500, MPU9250.GYRO_FS_1000, MPU9250.GYRO_FS_2000];
+	var gyro_value = MPU9250.GYRO_FS_250;
 	if (this._config.GYRO_FS > -1 && this._config.GYRO_FS < 4) gyro_value = gyro_fs[this._config.GYRO_FS];
 	this.setFullScaleGyroRange(gyro_value);
 	this.debug.Log('INFO', 'Set setFullScaleGyroRange to 0x' + MPU9250.GYRO_FS_2000.toString(16));
 	sleep.usleep(10000);
-	
+
 	// define accel range
-	accel_fs = [MPU9250.ACCEL_FS_2, MPU9250.ACCEL_FS_4, MPU9250.ACCEL_FS_8, MPU9250.ACCEL_FS_16];	
-	accel_value = MPU9250.ACCEL_FS_4;
+	var accel_fs = [MPU9250.ACCEL_FS_2, MPU9250.ACCEL_FS_4, MPU9250.ACCEL_FS_8, MPU9250.ACCEL_FS_16];
+
+	// TODO: SMW: Why is this variable not used?
+	var accel_value = MPU9250.ACCEL_FS_4;
 	if (this._config.ACCEL_FS > -1 && this._config.ACCEL_FS < 4) accel_value = accel_fs[this._config.ACCEL_FS];
 	this.setFullScaleAccelRange();
 	this.debug.Log('INFO', 'Set setFullScaleAccelRange to 0x' + MPU9250.ACCEL_FS_16.toString(16));
 	sleep.usleep(10000);
-	
+
 	// desiable sleepEnabled
 	this.setSleepEnabled(false);
 	this.debug.Log('INFO', 'SleepEnabled mode disabled');
 	sleep.usleep(10000);
 	this.debug.Log('INFO', 'END of initialization.');
 	this.debug.Log('INFO', 'Device id : 0x' + this.getIDDevice().toString(16));
-	this.debug.Log('INFO', 'Device is online ? ' + ((this.testDevice()) ? 'Yes': 'No'));
+	this.debug.Log('INFO', 'Device is online ? ' + ((this.testDevice()) ? 'Yes' : 'No'));
 	this.success = this.testDevice();
-	
+
 	if (this._config.UpMagneto) {
 		this.debug.Log('INFO', 'Enabled magnetometer. Starting initialization ....');
 		this.enableMagnetometer();
 		this.debug.Log('INFO', 'END of initialization.');
 	}
 	return this.success;
-}
+};
 
 /**------------------|[ FUNCTION ]|------------------**/
 /**
@@ -269,16 +274,16 @@ mpu9250.prototype.enableMagnetometer = function() {
 		this.debug.Log('INFO', 'Disable I2C Master');
 		this.setI2CMasterModeEnabled(false);
 		sleep.usleep(100000);
-		
+
 		this.debug.Log('INFO', 'Enable BYPASS');
 		this.setByPASSEnabled(true);
 		sleep.usleep(100000);
-		
-		buffer = this.getByPASSEnabled();
-		if (buffer & 0x02) {	
+
+		var buffer = this.getByPASSEnabled();
+		if (buffer & 0x02) {
 			this.debug.Log('INFO', 'Creation of a new Class ak8963.');
 			this.ak8963 = new ak8963(this._config);
-			
+
 			this.debug.Log('INFO', 'END of configuration of magnetometer.');
 		} else {
 			this.debug.Log('ERROR', 'Can\'t turn on RA_INT_PIN_CFG.');
@@ -307,7 +312,7 @@ mpu9250.prototype.getIDDevice = function() {
  */
 mpu9250.prototype.getTemperature = function() {
 	if (this.i2c) {
-		buffer = this.i2c.readBytes(MPU9250.TEMP_OUT_H, 2, function(){});
+		var buffer = this.i2c.readBytes(MPU9250.TEMP_OUT_H, 2, function(){});
 		return buffer.readInt16BE(0);
 	}
 	return false;
@@ -321,15 +326,17 @@ mpu9250.prototype.getTemperatureCelsius = function() {
 /*
 ((TEMP_OUT – RoomTemp_Offset)/Temp_Sensitivity) + 21degC
 */
-	if ((TEMP_OUT = this.getTemperature()) !== false) {
-		inc = (TEMP_OUT / 333.87) + 21.0;
+    var TEMP_OUT = this.getTemperature();
+	if (TEMP_OUT !== false) {
+		var inc = (TEMP_OUT / 333.87) + 21.0;
 		return inc + '°C';
 	}
 	return 'no data';
 };
 
 mpu9250.prototype.getTemperatureCelsiusDigital = function() {
-	if ((TEMP_OUT = this.getTemperature()) !== false) {
+    var TEMP_OUT = this.getTemperature();
+	if (TEMP_OUT !== false) {
 		return (TEMP_OUT / 333.87) + 21.0;
 	}
 	return 0;
@@ -341,7 +348,7 @@ mpu9250.prototype.getTemperatureCelsiusDigital = function() {
  */
 mpu9250.prototype.getMotion6 = function() {
 	if (this.i2c) {
-		buffer = this.i2c.readBytes(MPU9250.ACCEL_XOUT_H, 14, function(){});
+		var buffer = this.i2c.readBytes(MPU9250.ACCEL_XOUT_H, 14, function(){});
 		return [
 			buffer.readInt16BE(0),
 			buffer.readInt16BE(2),
@@ -361,24 +368,25 @@ mpu9250.prototype.getMotion6 = function() {
 
 mpu9250.prototype.getMotion9 = function() {
 	if (this.i2c) {
-		mpudata = this.getMotion6();
+		var mpudata = this.getMotion6();
+        var magdata;
 		if (this.ak8963) {
 			magdata = this.ak8963.getMotion6();
 		} else {
-			magdata = [0,0,0];
+			magdata = [0, 0, 0];
 		}
 		return mpudata.concat(magdata);
 	}
 	return false;
 };
- 
+
 /**
  * @name getAccel
  * @return array | false
- */ 
+ */
 mpu9250.prototype.getAccel = function() {
 	if (this.i2c) {
-		buffer = this.i2c.readBytes(MPU9250.ACCEL_XOUT_H, 6, function(){});
+		var buffer = this.i2c.readBytes(MPU9250.ACCEL_XOUT_H, 6, function(){});
 		return [
 			buffer.readInt16BE(0),
 			buffer.readInt16BE(2),
@@ -391,10 +399,10 @@ mpu9250.prototype.getAccel = function() {
 /**
  * @name getAccel
  * @return array | false
- */ 
+ */
 mpu9250.prototype.getGyro = function() {
 	if (this.i2c) {
-		buffer = this.i2c.readBytes(MPU9250.GYRO_XOUT_H, 6, function(){});
+		var buffer = this.i2c.readBytes(MPU9250.GYRO_XOUT_H, 6, function(){});
 		return [
 			buffer.readInt16BE(0),
 			buffer.readInt16BE(2),
@@ -410,7 +418,7 @@ mpu9250.prototype.getGyro = function() {
  */
 mpu9250.prototype.getSleepEnabled = function() {
 	if (this.i2c) {
-		return this.i2c.readBit(MPU9250.RA_PWR_MGMT_1, MPU9250.PWR1_SLEEP_BIT); 
+		return this.i2c.readBit(MPU9250.RA_PWR_MGMT_1, MPU9250.PWR1_SLEEP_BIT);
 	}
 	return false;
 };
@@ -421,7 +429,7 @@ mpu9250.prototype.getSleepEnabled = function() {
  */
 mpu9250.prototype.getClockSource = function() {
 	if (this.i2c) {
-		return this.i2c.readBit(MPU9250.RA_PWR_MGMT_1, MPU9250.PWR1_CLKSEL_BIT); 
+		return this.i2c.readBit(MPU9250.RA_PWR_MGMT_1, MPU9250.PWR1_CLKSEL_BIT);
 	}
 	return false;
 };
@@ -432,7 +440,7 @@ mpu9250.prototype.getClockSource = function() {
  */
  mpu9250.prototype.getFullScaleGyroRange = function() {
 	if (this.i2c) {
-		return this.i2c.readBit(MPU9250.RA_GYRO_CONFIG, MPU9250.PWR1_CLKSEL_BIT); 
+		return this.i2c.readBit(MPU9250.RA_GYRO_CONFIG, MPU9250.PWR1_CLKSEL_BIT);
 	}
 	return false;
 };
@@ -443,10 +451,10 @@ mpu9250.prototype.getClockSource = function() {
  */
 mpu9250.prototype.getFullScaleAccelRange = function() {
 	if (this.i2c) {
-		return this.i2c.readBit(MPU9250.RA_ACCEL_CONFIG, MPU9250.PWR1_CLKSEL_BIT); 
+		return this.i2c.readBit(MPU9250.RA_ACCEL_CONFIG, MPU9250.PWR1_CLKSEL_BIT);
 	}
 	return false;
-}
+};
 
 /**
  * @name getByPASSEnabled
@@ -511,7 +519,7 @@ mpu9250.prototype.setFullScaleAccelRange = function(adrs) {
  * @return undefined | false
  */
 mpu9250.prototype.setSleepEnabled = function(bool) {
-	adrs = (bool === true);
+	var adrs = (bool === true);
 	if (this.i2c) {
 		return this.i2c.writeBit(MPU9250.RA_PWR_MGMT_1, MPU9250.PWR1_SLEEP_BIT, adrs);
 	}
@@ -523,7 +531,7 @@ mpu9250.prototype.setSleepEnabled = function(bool) {
  * @return undefined | false
  */
 mpu9250.prototype.setI2CMasterModeEnabled = function(bool) {
-	adrs = (bool === true);
+	var adrs = (bool === true);
 	if (this.i2c) {
 		return this.i2c.writeBit(MPU9250.RA_USER_CTRL, MPU9250.USERCTRL_I2C_MST_EN_BIT, adrs);
 	}
@@ -535,7 +543,7 @@ mpu9250.prototype.setI2CMasterModeEnabled = function(bool) {
  * @return undefined | false
  */
 mpu9250.prototype.setByPASSEnabled = function(bool) {
-	adrs = (bool === true);
+	var adrs = (bool === true);
 	if (this.i2c) {
 		return this.i2c.writeBit(MPU9250.RA_INT_PIN_CFG, MPU9250.INTCFG_BYPASS_EN_BIT, adrs);
 	}
@@ -557,7 +565,7 @@ var ak8963 = function(config, callback) {
 	// connection with magnetometer
 	this.i2c = new LOCAL_I2C(this._config.ak_address, {device: this._config.device});
 	sleep.usleep(100000);
-	buffer = this.getIDDevice();
+	var buffer = this.getIDDevice();
 	this.debug.Log('INFO', 'Device ID is ' + buffer.toString(16));
 
 	if (buffer & 0x48) {
@@ -596,7 +604,7 @@ ak8963.prototype.getDataReady = function() {
 	return false;
 };
 
- 
+
 /**
  * @name getIDDevice
  * @return byte | false
@@ -669,50 +677,50 @@ mpu9250.prototype.Kalman_filter = function() {
 	this.Q_angle = 0.001;
 	this.Q_bias = 0.003;
 	this.R_measure = 0.03;
-	
+
 	this.angle = 0;
 	this.bias = 0;
 	this.rate = 0;
-	
-	this.P = [[0,0],[0,0]];
-	
+
+	this.P = [[0, 0], [0, 0]];
+
 	this.S = 0;
 	this.K = [];
 	this.Y = 0;
-	
+
 	this.getAngle = function(newAngle, newRate, dt) {
-		
+
 		this.rate = newRate - this.bias;
 		this.angle += dt * this.rate;
-		
-		this.P[0][0] += dt * (dt*this.P[1][1] - this.P[0][1] - this.P[1][0] + this.Q_angle);
+
+		this.P[0][0] += dt * (dt * this.P[1][1] - this.P[0][1] - this.P[1][0] + this.Q_angle);
 		this.P[0][1] -= dt * this.P[1][1];
 		this.P[1][0] -= dt * this.P[1][1];
 		this.P[1][1] += this.Q_bias * dt;
-		
+
 		this.S = this.P[0][0] + this.R_measure;
-		
+
 		this.K[0] = this.P[0][0] / this.S;
 		this.K[1] = this.P[1][0] / this.S;
-		
+
 		this.Y = newAngle - this.angle;
-		
+
 		this.angle += this.K[0] * this.Y;
 		this.bias += this.K[1] * this.Y;
-		
+
 		this.P[0][0] -= this.K[0] * this.P[0][0];
 		this.P[0][1] -= this.K[0] * this.P[0][1];
 		this.P[1][0] -= this.K[1] * this.P[0][0];
 		this.P[1][1] -= this.K[1] * this.P[0][1];
-		
+
 		return this.angle;
 	};
-	
+
 	this.getRate     = function() { return this.rate; };
 	this.getQangle   = function() { return this.Q_angle; };
 	this.getQbias    = function() { return this.Q_bias; };
 	this.getRmeasure = function() { return this.R_measure; };
-	
+
 	this.setAngle    = function(value) { this.angle = value; };
 	this.setQangle   = function(value) { this.Q_angle = value; };
 	this.setQbias    = function(value) { this.Q_bias = value; };
@@ -729,11 +737,11 @@ mpu9250.prototype.Kalman_filter = function() {
 var debugConsole = function(debug) {
 	this.enabled = debug || false;
 };
-debugConsole.prototype.Log = function(type,str) {
+debugConsole.prototype.Log = function(type, str) {
 	if (this.enabled) {
-		date = new Date();
-		strdate = date.getDate() + '/' + (date.getMonth() + 1) + '/' + date.getFullYear();
-		strhour = date.getHours() + ':' + date.getMinutes();
+		var date = new Date();
+		var strdate = date.getDate() + '/' + (date.getMonth() + 1) + '/' + date.getFullYear();
+		var strhour = date.getHours() + ':' + date.getMinutes();
 		console.log('[' + type.toUpperCase() + '][' + strhour + ' ' + strdate + ']:' + str);
 	}
 };
@@ -748,7 +756,7 @@ debugConsole.prototype.constructor = debugConsole;
 var LOCAL_I2C = function(adrs, params) {
 	MOD_I2C.call(this, adrs, params);
 };
- 
+
 LOCAL_I2C.prototype = Object.create(MOD_I2C.prototype);
 LOCAL_I2C.prototype.constructor = LOCAL_I2C;
 
@@ -757,13 +765,13 @@ LOCAL_I2C.prototype.bitMask = function(bit, length) {
 };
 
 LOCAL_I2C.prototype.readBit = function(adrs, bit, length, callback) {
-	callback = callback || function(e,r) {};
+	callback = callback || function(e, r) {};
 	var buf = this.readBytes(adrs, 1, callback);
 	return buf[0];
 };
 
 LOCAL_I2C.prototype.writeBits = function(adrs, bit, legnth, value, callback) {
-	callback = callback || function(e,r) {};
+	callback = callback || function(e, r) {};
 	var oldValue = this.readBytes(adrs, 1, callback);
 	var mask = this.bitMask(bit, legnth);
 	var newValue = oldValue ^ ((oldValue ^ (value << bit)) & mask);
@@ -771,7 +779,7 @@ LOCAL_I2C.prototype.writeBits = function(adrs, bit, legnth, value, callback) {
 };
 
 LOCAL_I2C.prototype.writeBit = function(adrs, bit, value, callback) {
-	callback = callback || function(e,r) {};
+	callback = callback || function(e, r) {};
 	return this.writeBits(adrs, bit, 1, value, callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "keywords": [
     "mpu9250"
   ],
-  "Dependencies": {
+  "dependencies": {
     "i2c": ">=0.2.1",
     "extend": ">=3.0.0",
     "sleep": ">=3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mpu9250",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Simple reading Data from mpu9250 with node.js and i2c package.",
   "main": "mpu9250.js",
   "scripts": {


### PR DESCRIPTION
This pull request has the following changes, in respective order:
- Lots of whitespace changes - sorry it's my editor.
- Added .gitignore for my sanity.
- Improved Readme.md: Added comments around default values.
- Added example.js - run this for a quick test.
- General code tidying:
  - Added whitespace, changed " to '.
  - Declared variables when appropriated (otherwise they get hoisted to global space).
  - Corrected spelling mistakes
- Fixed testDevice() - this would return true in many false cases.
- Introduced readByte function, this allows you quickly read a byte (not a bit).
- Changed the readBit to actually read a bit and corrected respective code. Previously it would read a byte, code in places using this function was very wonky.
- Removed superfluous code in `setBYPASSenabled()`, in the `'Magnetometer data is ready to work.'` section.  This didn't make sense for initialization.
- Added `getSensitivityAdjustmentValues()` function to return the factory settings for H value.  This means adding function to get these values: `getMagAttitude()`
- Added `scaleValues` (true/false) as a config option.  This will changes the result of `getMotion9()` and other functions.  When `scaleValues` is `true` then these functions return the actual values (e.g. g unit for accel, degrees / sec for gyro, etc).
- Fixed bug with some bit values (using `writeBits()`) not being set correctly.
- Improved print output, see below (with `DEBUG=true`).  This required some new functions and allowed for code tidying.  It also tests the actual status of the MPU9250 device (as opposed to just printing the config values):

``` Text
[INFO][4:39 2/6/2016]:Initialization MPU9250 ....
[INFO][4:39 2/6/2016]:Reset configuration MPU9250.
[INFO][4:39 2/6/2016]:Enabled magnetometer. Starting initialization ....
[INFO][4:39 2/6/2016]:END of magnetometer initialization.
[INFO][4:39 2/6/2016]:END of MPU9150 initialization.
[INFO][4:39 2/6/2016]:MPU9250:
[INFO][4:39 2/6/2016]:--> Device address: 0x68
[INFO][4:39 2/6/2016]:--> i2c bus: /dev/i2c-2
[INFO][4:39 2/6/2016]:--> Device ID: 0x71
[INFO][4:39 2/6/2016]:--> BYPASS enabled: Yes
[INFO][4:39 2/6/2016]:--> SleepEnabled Mode: Off
[INFO][4:39 2/6/2016]:--> i2c Master Mode: Disabled
[INFO][4:39 2/6/2016]:--> Power Management (0x6B, 0x6C):
[INFO][4:39 2/6/2016]:    --> Clock Source: 1 (Auto selects the best available clock source)
[INFO][4:39 2/6/2016]:    --> Accel enabled (x, y, z): (Yes, Yes, Yes)
[INFO][4:39 2/6/2016]:    --> Gyro enabled (x, y, z): (Yes, Yes, Yes)
[INFO][4:39 2/6/2016]:Accelerometer:
[INFO][4:39 2/6/2016]:--> Full Scale Range (0x1C): ±2g (0)
[INFO][4:39 2/6/2016]:--> Scalar: 1/16384
[INFO][4:39 2/6/2016]:Gyroscope:
[INFO][4:39 2/6/2016]:--> Full Scale Range (0x1B): +250dps (0)
[INFO][4:39 2/6/2016]:--> Scalar: 1/131
[INFO][4:39 2/6/2016]:Magnetometer (Compass):
[INFO][4:39 2/6/2016]:--> i2c address: 0xc
[INFO][4:39 2/6/2016]:--> Device ID: 0x48
[INFO][4:39 2/6/2016]:--> Mode: 0x06 (Continuous measurement mode 2)
[INFO][4:39 2/6/2016]:--> Scalars:
[INFO][4:39 2/6/2016]:  --> x:1.1796875
[INFO][4:39 2/6/2016]:  --> y:1.18359375
[INFO][4:39 2/6/2016]:  --> z:1.140625
Time    Accel.x Accel.y Accel.z Gyro.x  Gyro.y  Gyro.z  Mag.x   Mag.y   Mag.z   Temp(°C)
0.011   0.00    0.00    1.07    1.12    0.34    -1.68   10.62   5.92    4.56    23.92
0.011   0.01    -0.00   1.07    1.14    0.28    -1.63   10.62   5.92    4.56    23.83
0.004   0.00    -0.00   1.06    1.15    0.19    -1.81   10.62   5.92    4.56    23.83
0.004   0.00    0.00    1.06    1.02    0.28    -1.63   10.62   5.92    4.56    23.83
0.004   0.00    -0.00   1.07    0.82    0.11    -1.33   10.62   5.92    4.56    23.88
0.004   0.00    -0.00   1.07    0.85    -0.12   -1.64   10.62   5.92    4.56    24.16
```
