### PR TITLE
Added standard deviation and averaging for example.js

### DIFF
--- a/example.js
+++ b/example.js
@@ -164,37 +164,24 @@ function Stats(vectorNames, numStats) {
 Stats.prototype.add = function(vectorName, x, y, z) {
     var v = this.vectors[vectorName];
     var len = v.x.length;
-    if (len < this.numStats) {
-        v.x.push(x);
-        v.y.push(y);
-        v.z.push(z);
-        v.pos = len;
+    if (v.pos >= this.numStats) {
+        v.pos = 0;
     } else {
-        if (v.pos >= len) {
-            v.pos = 0;
-        } else {
-            v.pos += 1;
-        }
-        v.x[v.pos] = x;
-        v.y[v.pos] = y;
-        v.z[v.pos] = z;
+        v.pos += 1;
     }
+    v.x[v.pos] = x;
+    v.y[v.pos] = y;
+    v.z[v.pos] = z;
 };
 Stats.prototype.addValue = function(vectorName, x) {
     var v = this.vectors[vectorName];
     v.isValue = true;
-    var len = v.x.length;
-    if (len < this.numStats) {
-        v.x.push(x);
-        v.pos = len;
+    if (v.pos >= this.numStats) {
+        v.pos = 0;
     } else {
-        if (v.pos >= len) {
-            v.pos = 0;
-        } else {
-            v.pos += 1;
-        }
-        v.x[v.pos] = x;
+        v.pos += 1;
     }
+    v.x[v.pos] = x;
 };
 Stats.prototype.printStats = function () {
     if (this.done) return;

--- a/example.js
+++ b/example.js
@@ -71,6 +71,12 @@ var mpu = new mpu9250({
 
 if (mpu.initialize()) {
 
+    var ACCEL_NAME = 'Accel (g)';
+    var GYRO_NAME = 'Gyro (°/sec)';
+    var MAG_NAME = 'Mag (uT)';
+    var HEADING_NAME = 'Heading (°)';
+    var stats = new Stats([ACCEL_NAME, GYRO_NAME, MAG_NAME, HEADING_NAME], 1000);
+
     console.log('\n   Time     Accel.x  Accel.y  Accel.z  Gyro.x   Gyro.y   Gyro.z   Mag.x   Mag.y   Mag.z    Temp(°C) heading(°)');
     setInterval(function() {
         var start = new Date().getTime();
@@ -83,6 +89,10 @@ if (mpu.initialize()) {
         for (var i = 0; i < m9.length; i++) {
             str += p(m9[i]);
         }
+        stats.add(ACCEL_NAME, m9[0], m9[1], m9[2]);
+        stats.add(GYRO_NAME, m9[3], m9[4], m9[5]);
+        stats.add(MAG_NAME, m9[6], m9[7], m9[8]);
+        stats.addValue(HEADING_NAME, calcHeading(m9[6], m9[7]));
 
         process.stdout.write(p(t) + str + p(mpu.getTemperatureCelsiusDigital()) + p(calcHeading(m9[6], m9[7])) + '\r');
     }, 5);
@@ -107,3 +117,125 @@ function calcHeading(x, y) {
 
     return heading;
 }
+
+
+/**
+ * Calculate Statistics
+ * @param {[string]} names The names of the vectors.
+ */
+function Stats(vectorNames, numStats) {
+
+    this.vectorNames = vectorNames;
+    this.numStats = numStats;
+    this.vectors = {};
+    this.done = false;
+
+    for (var i = 0; i < vectorNames.length; i += 1) {
+        var name = vectorNames[i];
+        this.vectors[name] = {
+            x: [],
+            y: [],
+            z: [],
+            pos: 0
+        };
+    }
+
+    function exitHandler(options, err) {
+        if (err) {
+            console.log(err.stack);
+        } else {
+            this.printStats();
+        }
+        if (options.exit) {
+            var exit = process.exit;
+            exit();
+        }
+    }
+
+    // do something when app is closing
+    process.on('exit', exitHandler.bind(this, {cleanup: true}));
+
+    // catches ctrl+c event
+    process.on('SIGINT', exitHandler.bind(this, {exit: true}));
+
+    // catches uncaught exceptions
+    process.on('uncaughtException', exitHandler.bind(this, {exit: true}));
+}
+Stats.prototype.add = function(vectorName, x, y, z) {
+    var v = this.vectors[vectorName];
+    var len = v.x.length;
+    if (len < this.numStats) {
+        v.x.push(x);
+        v.y.push(y);
+        v.z.push(z);
+        v.pos = len;
+    } else {
+        if (v.pos >= len) {
+            v.pos = 0;
+        } else {
+            v.pos += 1;
+        }
+        v.x[v.pos] = x;
+        v.y[v.pos] = y;
+        v.z[v.pos] = z;
+    }
+};
+Stats.prototype.addValue = function(vectorName, x) {
+    var v = this.vectors[vectorName];
+    v.isValue = true;
+    var len = v.x.length;
+    if (len < this.numStats) {
+        v.x.push(x);
+        v.pos = len;
+    } else {
+        if (v.pos >= len) {
+            v.pos = 0;
+        } else {
+            v.pos += 1;
+        }
+        v.x[v.pos] = x;
+    }
+};
+Stats.prototype.printStats = function () {
+    if (this.done) return;
+    this.done = true;
+
+    console.log('\n\n\nStatistics:');
+    console.log('           average   std. dev.');
+    for (var i = 0; i < this.vectorNames.length; i += 1) {
+        var name = this.vectorNames[i];
+        var v = this.vectors[name];
+        console.log(name + ':');
+        console.log(' -> x: ', average(v.x).toFixed(5), standardDeviation(v.x).toFixed(5));
+        if (!v.isValue) {
+            console.log(' -> y: ', average(v.y).toFixed(5), standardDeviation(v.y).toFixed(5));
+            console.log(' -> z: ', average(v.z).toFixed(5), standardDeviation(v.z).toFixed(5));
+        }
+        console.log(' -> num samples: ', v.x.length);
+        console.log();
+    }
+
+    function standardDeviation(values) {
+        var avg = average(values);
+
+        var squareDiffs = values.map(function (value) {
+            var diff = value - avg;
+            var sqrDiff = diff * diff;
+            return sqrDiff;
+        });
+
+        var avgSquareDiff = average(squareDiffs);
+
+        var stdDev = Math.sqrt(avgSquareDiff);
+        return stdDev;
+    }
+
+    function average(values) {
+        var sumData = values.reduce(function (sum, value) {
+            return sum + value;
+        }, 0);
+
+        var avg = sumData / values.length;
+        return avg;
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,30 +1,28 @@
 {
-  "name": "mpu9250",
-  "version": "0.1.5",
-  "description": "Simple reading Data from mpu9250 with node.js and i2c package.",
-  "main": "mpu9250.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/miniben-90/mpu9250.git"
-  },
-  "bugs": {
-	"url": "https://github.com/miniben-90/mpu9250/issues"
-  },
-  "keywords": [
-    "mpu9250"
-  ],
-  "dependencies": {
-    "i2c": ">=0.2.1",
-    "extend": ">=3.0.0",
-    "sleep": ">=3.0.0"
-  },
-  "author": "BENKHADRA Hocine",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/miniben-90/mpu9250/issues"
-  },
-  "homepage": "https://github.com/miniben-90/mpu9250"
+    "name": "mpu9250",
+    "version": "0.1.6",
+    "description": "Simple reading Data from mpu9250 with node.js and i2c package.",
+    "main": "mpu9250.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/miniben-90/mpu9250.git"
+    },
+    "bugs": {
+        "url": "https://github.com/miniben-90/mpu9250/issues"
+    },
+    "keywords": [
+        "mpu9250"
+    ],
+    "dependencies": {
+        "extend": ">=3.0.0",
+        "geomagnetism": "0.0.2",
+        "i2c": ">=0.2.1",
+        "sleep": ">=3.0.0"
+    },
+    "author": "BENKHADRA Hocine",
+    "license": "MIT",
+    "homepage": "https://github.com/miniben-90/mpu9250"
 }


### PR DESCRIPTION
Some IMUs (Inertial Measurement Units) require sigma, the standard deviation or variance to filter the noise.  When you exit `node example.js` with `[CTRL] + C` the statistics will be printed out.

I am hoping this will be the last PR for a while.
