### PR TITLE
Fixed version numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mpu9250",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "Simple reading Data from mpu9250 with node.js and i2c package.",
     "main": "mpu9250.js",
     "scripts": {
@@ -17,10 +17,10 @@
         "mpu9250"
     ],
     "dependencies": {
-        "extend": ">=3.0.0",
+        "extend": "3.0.0",
         "geomagnetism": "0.0.2",
-        "i2c": ">=0.2.1",
-        "sleep": ">=3.0.0"
+        "i2c": "0.2.1",
+        "sleep": "3.0.0"
     },
     "author": "BENKHADRA Hocine",
     "license": "MIT",


### PR DESCRIPTION
I had a problem that since the dependencies use ">=" it will use the latest version of the particular module.  This breaks i2c (0.2.3 get installed instead of 0.2.1) and sleep (5.0.0 gets installed instead of 3.0.0).  Fixing these version numbers will stop this breakage.